### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/flipch/micode-beads/security/code-scanning/1](https://github.com/flipch/micode-beads/security/code-scanning/1)

In general, the problem is fixed by explicitly adding a `permissions:` block to the workflow or to individual jobs, granting only the minimal required scopes. For a pure CI workflow that just checks out code and runs tests, `contents: read` is typically sufficient, since no step writes to the repository, changes PRs, or interacts with other GitHub resources.

The single best fix here is to add a top-level `permissions:` block right under the workflow `name:` (or under `on:`) so that it applies to all jobs that don’t override it. For this workflow, we can set `contents: read`, which is the minimal permission required for `actions/checkout` to read the repository contents. No other scopes (like `issues`, `pull-requests`, or `packages`) are needed based on the shown steps. Concretely, in `.github/workflows/ci.yml`, insert:

```yml
permissions:
  contents: read
```

between the existing `name: CI` line and the `on:` block. No imports or additional methods are required, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
