### PR TITLE
fix(ci): remove duplicate permissions block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: CI
 
-permissions:
-  contents: read
-
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Two PRs (#2 and #3) both added permissions blocks, causing invalid YAML that broke CI.