### PR TITLE
fix(ci): use step output instead of secrets in if conditions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,16 +50,29 @@ jobs:
             echo "published=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check auth configuration
+        id: auth
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ "${{ vars.NPM_PUBLISH_OIDC }}" = "true" ]; then
+            echo "method=oidc" >> "$GITHUB_OUTPUT"
+          elif [ -n "$NPM_TOKEN" ]; then
+            echo "method=token" >> "$GITHUB_OUTPUT"
+          else
+            echo "method=none" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm (OIDC trusted publishing)
-        if: steps.published.outputs.published != 'true' && vars.NPM_PUBLISH_OIDC == 'true'
+        if: steps.published.outputs.published != 'true' && steps.auth.outputs.method == 'oidc'
         run: npm publish --provenance --access public --ignore-scripts
 
       - name: Publish to npm (token)
-        if: steps.published.outputs.published != 'true' && vars.NPM_PUBLISH_OIDC != 'true' && secrets.NPM_TOKEN != ''
+        if: steps.published.outputs.published != 'true' && steps.auth.outputs.method == 'token'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public --ignore-scripts
 
       - name: Publish skipped (no auth)
-        if: steps.published.outputs.published != 'true' && vars.NPM_PUBLISH_OIDC != 'true' && secrets.NPM_TOKEN == ''
-        run: echo "No publish auth configured. Set vars.NPM_PUBLISH_OIDC=true for OIDC or add NPM_TOKEN."
+        if: steps.published.outputs.published != 'true' && steps.auth.outputs.method == 'none'
+        run: echo "No publish auth configured. Set vars.NPM_PUBLISH_OIDC=true for OIDC or add NPM_TOKEN secret."


### PR DESCRIPTION
## Problem

GitHub Actions doesn't allow referencing `secrets.*` in `if:` conditions:

```
Unrecognized named-value: 'secrets'
```

## Solution

Added a "Check auth configuration" step that:
1. Receives the secret via `env:` (which IS allowed)
2. Determines the publish method (`oidc`, `token`, or `none`)
3. Outputs the method for use in subsequent `if:` conditions

This follows GitHub's recommended pattern for conditional logic based on secrets.