### PR TITLE
feat(config): add reasoning effort and extended thinking support

### DIFF
--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -67,15 +67,43 @@ export function loadDefaultModel(configDir?: string): string | null {
 }
 
 // Safe properties that users can override
-const SAFE_AGENT_PROPERTIES = ["model", "temperature", "maxTokens"] as const;
+const SAFE_AGENT_PROPERTIES = [
+  "model",
+  "temperature",
+  "maxTokens",
+  // Reasoning effort for OpenAI reasoning models (Codex 5.3+)
+  // Values: "low" | "medium" | "high" | "xhigh"
+  "reasoningEffort",
+  // Effort level for Anthropic models (Opus 4.6+)
+  // Values: "low" | "medium" | "high" | "max"
+  "effort",
+  // Extended thinking config for Anthropic models
+  // Values: { type: "adaptive" } | { type: "enabled", budgetTokens: number }
+  "thinking",
+] as const;
 
 // Built-in OpenCode models that don't require validation (always available)
 const BUILTIN_MODELS = new Set(["opencode/big-pickle"]);
+
+// Reasoning effort levels for OpenAI reasoning models (Codex 5.3+)
+export type OpenAIReasoningEffort = "low" | "medium" | "high" | "xhigh";
+
+// Effort levels for Anthropic models (Opus 4.6+)
+export type AnthropicEffort = "low" | "medium" | "high" | "max";
+
+// Extended thinking config for Anthropic models
+export type ThinkingConfig = { type: "adaptive" } | { type: "enabled"; budgetTokens: number };
 
 export interface AgentOverride {
   model?: string;
   temperature?: number;
   maxTokens?: number;
+  // OpenAI reasoning models (Codex 5.3+) - controls reasoning depth
+  reasoningEffort?: OpenAIReasoningEffort;
+  // Anthropic models (Opus 4.6+) - controls intelligence/speed tradeoff
+  effort?: AnthropicEffort;
+  // Anthropic extended thinking - let model decide when to think deeply
+  thinking?: ThinkingConfig;
 }
 
 export interface MicodeFeatures {


### PR DESCRIPTION
## Summary

- Add support for `reasoningEffort` parameter for OpenAI reasoning models (Codex 5.3+)
- Add support for `effort` parameter for Anthropic models (Opus 4.6+)  
- Add support for `thinking` config for Anthropic extended thinking

## New Configuration Options

### OpenAI Reasoning Models (Codex 5.3+)
```json
{
  "agents": {
    "reviewer": {
      "model": "openai/gpt-5.3-codex",
      "reasoningEffort": "xhigh"
    }
  }
}
```
Values: `"low"` | `"medium"` | `"high"` | `"xhigh"`

### Anthropic Models (Opus 4.6+)
```json
{
  "agents": {
    "implementer": {
      "model": "anthropic/claude-opus-4-6",
      "effort": "max",
      "thinking": { "type": "adaptive" }
    }
  }
}
```

**Effort values:** `"low"` | `"medium"` | `"high"` | `"max"`

**Thinking values:** 
- `{ "type": "adaptive" }` - Let model decide when to think deeply
- `{ "type": "enabled", "budgetTokens": 32000 }` - Fixed thinking budget

## Why

The new Feb 2026 models (Claude Opus 4.6 and GPT-5.3-Codex) support reasoning effort parameters that significantly impact quality:

- **Opus 4.6**: `effort: "max"` enables deepest reasoning for complex fintech/backend code
- **Codex 5.3**: `reasoningEffort: "xhigh"` was used in all official benchmarks

## Test plan

- [x] TypeScript compiles without errors
- [x] Existing tests pass (13/13)
- [x] Config properties flow through to agent configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)