### PR TITLE
fix(ci): inline release jobs into release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,9 +12,104 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
 
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           release-type: node
-          package-name: micode-beads
+
+  build-standalone:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build standalone binaries
+        run: sh scripts/build-standalone.sh
+
+      - name: Upload binaries to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ needs.release-please.outputs.tag_name }}" \
+            dist/micode-beads-darwin-arm64 \
+            dist/micode-beads-darwin-arm64.sha256 \
+            dist/micode-beads-darwin-x64 \
+            dist/micode-beads-darwin-x64.sha256 \
+            dist/micode-beads-linux-arm64 \
+            dist/micode-beads-linux-arm64.sha256 \
+            dist/micode-beads-linux-x64 \
+            dist/micode-beads-linux-x64.sha256
+
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' && vars.NPM_PUBLISH_OIDC == 'true' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Use npm >= 11.5.1 for trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build
+        run: bun run build
+
+      - name: Test
+        run: bun test
+
+      - name: Check if already published
+        id: check
+        run: |
+          NAME=$(node -p 'require("./package.json").name')
+          VERSION=$(node -p 'require("./package.json").version')
+          if npm view "${NAME}@${VERSION}" version > /dev/null 2>&1; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Already published ${NAME}@${VERSION}"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm (OIDC)
+        if: steps.check.outputs.skip != 'true'
+        env:
+          NODE_AUTH_TOKEN: ''
+          NPM_TOKEN: ''
+        run: |
+          npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Release
 
 on:
-  release:
-    types:
-      - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v1.3.0)'
+        required: true
+        type: string
 
 jobs:
   build-standalone:
@@ -14,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -29,7 +34,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ github.event.release.tag_name }}" \
+          gh release upload "${{ inputs.tag }}" \
             dist/micode-beads-darwin-arm64 \
             dist/micode-beads-darwin-arm64.sha256 \
             dist/micode-beads-darwin-x64 \
@@ -49,6 +54,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
 
       - uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary

- Inline build-standalone and npm publish jobs directly into release-please.yml, chained via `needs`/`outputs`
- Root cause: release-please creates releases via `GITHUB_TOKEN`, which doesn't trigger cross-workflow `release: published` events (GitHub Actions limitation to prevent loops)
- This meant v1.1.0, v1.2.0, and v1.3.0 never got npm published or binary assets uploaded
- Convert release.yml to `workflow_dispatch` only, so existing releases can be manually backfilled

## Test plan
- [ ] Merge this PR, then manually dispatch release.yml with tag `v1.3.0` to backfill
- [ ] Verify npm has v1.3.0 published
- [ ] Verify GitHub release v1.3.0 has binary assets
- [ ] Future releases via release-please will automatically build+publish

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>