### PR TITLE
fix(ci): add id-token permission for npm OIDC publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release-please:


### PR DESCRIPTION
## Summary

- Add `id-token: write` to workflow-level permissions in release-please.yml
- Job-level permissions cannot exceed workflow-level permissions, so the publish job's `id-token: write` was silently denied
- This caused the v1.3.1 npm publish to fail with `ENEEDAUTH`

## Test plan
- [ ] After merge, release-please will create a v1.3.2 PR
- [ ] Merging that PR should trigger build+publish successfully