### PR TITLE
fix(ci): use workflow_call for npm publish OIDC compatibility

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 jobs:
   release-please:
@@ -23,94 +22,12 @@ jobs:
         with:
           release-type: node
 
-  build-standalone:
+  release:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    runs-on: ubuntu-latest
-
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
     permissions:
       contents: write
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Build standalone binaries
-        run: sh scripts/build-standalone.sh
-
-      - name: Upload binaries to release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload "${{ needs.release-please.outputs.tag_name }}" \
-            dist/micode-beads-darwin-arm64 \
-            dist/micode-beads-darwin-arm64.sha256 \
-            dist/micode-beads-darwin-x64 \
-            dist/micode-beads-darwin-x64.sha256 \
-            dist/micode-beads-linux-arm64 \
-            dist/micode-beads-linux-arm64.sha256 \
-            dist/micode-beads-linux-x64 \
-            dist/micode-beads-linux-x64.sha256
-
-  publish:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' && vars.NPM_PUBLISH_OIDC == 'true' }}
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
       id-token: write
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Use npm >= 11.5.1 for trusted publishing
-        run: npm install -g npm@latest
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Build
-        run: bun run build
-
-      - name: Test
-        run: bun test
-
-      - name: Check if already published
-        id: check
-        run: |
-          NAME=$(node -p 'require("./package.json").name')
-          VERSION=$(node -p 'require("./package.json").version')
-          if npm view "${NAME}@${VERSION}" version > /dev/null 2>&1; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Already published ${NAME}@${VERSION}"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Publish to npm (OIDC)
-        if: steps.check.outputs.skip != 'true'
-        env:
-          NODE_AUTH_TOKEN: ''
-          NPM_TOKEN: ''
-        run: |
-          npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,12 @@ on:
         description: 'Release tag (e.g., v1.3.0)'
         required: true
         type: string
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v1.3.0)'
+        required: true
+        type: string
 
 jobs:
   build-standalone:


### PR DESCRIPTION
## Summary

npm trusted publishing OIDC tokens are scoped to the workflow file. Publishing from `release-please.yml` fails with `ENEEDAUTH` because the OIDC trust on npmjs.com is configured for `release.yml`.

Fix: have `release-please.yml` call `release.yml` via `workflow_call` so the OIDC token originates from the correct workflow.

Also adds `workflow_call` trigger to `release.yml` alongside the existing `workflow_dispatch`.