### PR TITLE
fix(installer): redirect info message to stderr in resolve_version

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -144,7 +144,7 @@ resolve_version() {
     echo "$MICODE_VERSION"
     return
   fi
-  info "Fetching latest version from GitHub..."
+  info "Fetching latest version from GitHub..." >&2
   version="$(fetch_url "${GITHUB_API}/repos/${REPO}/releases/latest" \
     | grep '"tag_name"' \
     | sed 's/.*"tag_name": *"v\{0,1\}\([^"]*\)".*/\1/')"


### PR DESCRIPTION
## Summary
- The `resolve_version` function printed an info message to stdout, which got captured by `version="$(resolve_version)"`, polluting the version string with `"info Fetching latest version from GitHub..."` and breaking all download URLs
- Fixed by redirecting the `info` call to stderr (`>&2`), matching the convention already used by `error()`

## Test plan
- [x] Removed existing `micode-beads` binary
- [x] Ran `sh scripts/install.sh` from clean state — version resolved cleanly as `1.3.6`, binary downloaded and installed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)