### PR TITLE
fix: write opencode.json plugin as array, never overwrite user config

### DIFF
--- a/src/cli/doctor-fixes.ts
+++ b/src/cli/doctor-fixes.ts
@@ -143,9 +143,7 @@ const opencodeJsonExistsFix: DiagnosticFix = {
     }
 
     const config = {
-      plugin: {
-        "micode-beads": {},
-      },
+      plugin: ["micode-beads"],
     };
 
     writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
@@ -161,7 +159,7 @@ const opencodeJsonExistsFix: DiagnosticFix = {
 
 const opencodeJsonValidFix: DiagnosticFix = {
   checkId: "opencode-json-valid",
-  isDestructive: true,
+  isDestructive: false,
   run: async (projectDir: string, _interactive: boolean): Promise<FixResult> => {
     const configPath = join(projectDir, "opencode.json");
 
@@ -184,23 +182,11 @@ const opencodeJsonValidFix: DiagnosticFix = {
       }
     }
 
-    const backupPath = `${configPath}.backup`;
-    const originalContent = readFileSync(configPath, "utf-8");
-    writeFileSync(backupPath, originalContent);
-
-    const freshConfig = {
-      plugin: {
-        "micode-beads": {},
-      },
-    };
-
-    writeFileSync(configPath, `${JSON.stringify(freshConfig, null, 2)}\n`);
-
     return {
       checkId: "opencode-json-valid",
-      status: "FIXED",
-      message: "Replaced malformed opencode.json with valid configuration",
-      action: `Original backed up to ${backupPath}`,
+      status: "MANUAL",
+      message: "opencode.json contains invalid JSON",
+      action: `Fix the JSON syntax in ${configPath} manually, then re-run \`micode-beads doctor --fix\` to register the plugin.`,
     };
   },
 };
@@ -243,20 +229,20 @@ const pluginRegisteredFix: DiagnosticFix = {
         }
         config.plugin.push("micode-beads");
       } else if (typeof config.plugin === "object" && config.plugin !== null) {
-        const pluginObj = config.plugin as Record<string, unknown>;
-        if ("micode-beads" in pluginObj) {
+        if ("micode-beads" in (config.plugin as Record<string, unknown>)) {
           return {
             checkId: "plugin-registered",
             status: "SKIPPED",
             message: "micode-beads is already registered in opencode.json",
           };
         }
-        pluginObj["micode-beads"] = {};
+        const existing = Object.keys(config.plugin as Record<string, unknown>);
+        config.plugin = [...existing, "micode-beads"];
       } else {
-        config.plugin = { "micode-beads": {} };
+        config.plugin = ["micode-beads"];
       }
     } else {
-      config.plugin = { "micode-beads": {} };
+      config.plugin = ["micode-beads"];
     }
 
     writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -18,7 +18,7 @@ interface ConfigResult {
 }
 
 interface OpencodeJson {
-  plugin?: Record<string, unknown> | string[];
+  plugin?: string[] | Record<string, unknown>;
   [key: string]: unknown;
 }
 
@@ -68,14 +68,13 @@ function createOrUpdateOpencodeJson(projectDir: string): ConfigResult {
       return { created: false, updated: false, path: configPath };
     }
 
-    let updatedPlugin: Record<string, unknown> | string[];
+    let updatedPlugin: string[];
     if (Array.isArray(existing.plugin)) {
       updatedPlugin = [...existing.plugin, "micode-beads"];
+    } else if (typeof existing.plugin === "object" && existing.plugin !== null) {
+      updatedPlugin = [...Object.keys(existing.plugin), "micode-beads"];
     } else {
-      updatedPlugin = {
-        ...(typeof existing.plugin === "object" && existing.plugin !== null ? existing.plugin : {}),
-        "micode-beads": {},
-      };
+      updatedPlugin = ["micode-beads"];
     }
 
     const updated: OpencodeJson = { ...existing, plugin: updatedPlugin };
@@ -84,9 +83,7 @@ function createOrUpdateOpencodeJson(projectDir: string): ConfigResult {
   }
 
   const newConfig: OpencodeJson = {
-    plugin: {
-      "micode-beads": {},
-    },
+    plugin: ["micode-beads"],
   };
   writeFileSync(configPath, `${JSON.stringify(newConfig, null, 2)}\n`);
   return { created: true, updated: false, path: configPath };

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,12 +73,12 @@ if (process.env.FIRECRAWL_API_KEY) {
 const OpenCodeConfigPlugin: Plugin = async (ctx) => {
   // Validate external tool dependencies at startup
   const astGrepStatus = await checkAstGrepAvailable();
-  if (!astGrepStatus.available) {
+  if (!astGrepStatus.available && process.env.MICODE_VERBOSE) {
     console.warn(`[micode-beads] ${astGrepStatus.message}`);
   }
 
   const btcaStatus = await checkBtcaAvailable();
-  if (!btcaStatus.available) {
+  if (!btcaStatus.available && process.env.MICODE_VERBOSE) {
     console.warn(`[micode-beads] ${btcaStatus.message}`);
   }
 

--- a/tests/cli/doctor-fixes.test.ts
+++ b/tests/cli/doctor-fixes.test.ts
@@ -38,7 +38,7 @@ describe("fixes registry", () => {
 
   it("should have correct isDestructive flags", () => {
     const destructiveIds = fixes.filter((f) => f.isDestructive).map((f) => f.checkId);
-    expect(destructiveIds).toEqual(["opencode-json-valid"]);
+    expect(destructiveIds).toEqual([]);
 
     const nonDestructiveIds = fixes.filter((f) => !f.isDestructive).map((f) => f.checkId);
     expect(nonDestructiveIds).toContain("path-correct");
@@ -198,7 +198,7 @@ describe("opencode-json-exists fix", () => {
 
     const content = JSON.parse(readFileSync(configPath, "utf-8"));
     expect(content.plugin).toBeDefined();
-    expect(content.plugin["micode-beads"]).toBeDefined();
+    expect(content.plugin).toContain("micode-beads");
   });
 
   it("should return SKIPPED when opencode.json already exists", async () => {
@@ -233,9 +233,9 @@ describe("opencode-json-valid fix", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("should be marked as destructive", () => {
+  it("should not be marked as destructive", () => {
     const fix = fixes.find((f) => f.checkId === "opencode-json-valid")!;
-    expect(fix.isDestructive).toBe(true);
+    expect(fix.isDestructive).toBe(false);
   });
 
   it("should return SKIPPED when opencode.json does not exist", async () => {
@@ -247,7 +247,7 @@ describe("opencode-json-valid fix", () => {
   });
 
   it("should return SKIPPED when opencode.json is already valid", async () => {
-    writeFileSync(join(tempDir, "opencode.json"), '{"plugin": {"micode-beads": {}}}');
+    writeFileSync(join(tempDir, "opencode.json"), '{"plugin": ["micode-beads"]}');
 
     const fix = fixes.find((f) => f.checkId === "opencode-json-valid")!;
     const result = await fix.run(tempDir, true);
@@ -256,51 +256,32 @@ describe("opencode-json-valid fix", () => {
     expect(result.message).toContain("already valid");
   });
 
-  it("should replace malformed JSON and create backup", async () => {
+  it("should return MANUAL for malformed JSON instead of overwriting", async () => {
     const configPath = join(tempDir, "opencode.json");
     writeFileSync(configPath, "{ not valid json }");
 
     const fix = fixes.find((f) => f.checkId === "opencode-json-valid")!;
     const result = await fix.run(tempDir, true);
 
-    expect(result.status).toBe("FIXED");
-    expect(result.message).toContain("Replaced malformed");
-    expect(result.action).toContain(".backup");
+    expect(result.status).toBe("MANUAL");
+    expect(result.message).toContain("invalid JSON");
+    expect(result.action).toContain("Fix the JSON syntax");
 
-    const newContent = JSON.parse(readFileSync(configPath, "utf-8"));
-    expect(newContent.plugin).toBeDefined();
-    expect(newContent.plugin["micode-beads"]).toBeDefined();
-
-    const backupPath = `${configPath}.backup`;
-    expect(existsSync(backupPath)).toBe(true);
-    expect(readFileSync(backupPath, "utf-8")).toBe("{ not valid json }");
+    // Original file should be untouched
+    expect(readFileSync(configPath, "utf-8")).toBe("{ not valid json }");
   });
 
-  it("should replace when JSON is an array instead of object", async () => {
+  it("should return MANUAL when JSON is an array instead of object", async () => {
     const configPath = join(tempDir, "opencode.json");
     writeFileSync(configPath, "[]");
 
     const fix = fixes.find((f) => f.checkId === "opencode-json-valid")!;
     const result = await fix.run(tempDir, true);
 
-    expect(result.status).toBe("FIXED");
+    expect(result.status).toBe("MANUAL");
 
-    const newContent = JSON.parse(readFileSync(configPath, "utf-8"));
-    expect(typeof newContent).toBe("object");
-    expect(Array.isArray(newContent)).toBe(false);
-  });
-
-  it("should be idempotent: second run returns SKIPPED", async () => {
-    const configPath = join(tempDir, "opencode.json");
-    writeFileSync(configPath, "not json");
-
-    const fix = fixes.find((f) => f.checkId === "opencode-json-valid")!;
-
-    const first = await fix.run(tempDir, true);
-    expect(first.status).toBe("FIXED");
-
-    const second = await fix.run(tempDir, true);
-    expect(second.status).toBe("SKIPPED");
+    // Original file should be untouched
+    expect(readFileSync(configPath, "utf-8")).toBe("[]");
   });
 });
 
@@ -344,11 +325,11 @@ describe("plugin-registered fix", () => {
     expect(result.message).toContain("Added micode-beads");
 
     const content = JSON.parse(readFileSync(configPath, "utf-8"));
-    expect(content.plugin["micode-beads"]).toBeDefined();
+    expect(content.plugin).toContain("micode-beads");
     expect(content.model).toBe("test");
   });
 
-  it("should add micode-beads to existing plugin object", async () => {
+  it("should convert existing plugin object to array and add micode-beads", async () => {
     const configPath = join(tempDir, "opencode.json");
     writeFileSync(configPath, '{"plugin": {"other-plugin": {}}}');
 
@@ -358,8 +339,9 @@ describe("plugin-registered fix", () => {
     expect(result.status).toBe("FIXED");
 
     const content = JSON.parse(readFileSync(configPath, "utf-8"));
-    expect(content.plugin["micode-beads"]).toBeDefined();
-    expect(content.plugin["other-plugin"]).toBeDefined();
+    expect(Array.isArray(content.plugin)).toBe(true);
+    expect(content.plugin).toContain("micode-beads");
+    expect(content.plugin).toContain("other-plugin");
   });
 
   it("should add micode-beads to existing plugin array", async () => {
@@ -386,7 +368,8 @@ describe("plugin-registered fix", () => {
     expect(result.status).toBe("FIXED");
 
     const content = JSON.parse(readFileSync(configPath, "utf-8"));
-    expect(content.plugin["micode-beads"]).toBeDefined();
+    expect(Array.isArray(content.plugin)).toBe(true);
+    expect(content.plugin).toContain("micode-beads");
   });
 
   it("should return SKIPPED when micode-beads is already registered (object format)", async () => {

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -35,7 +35,8 @@ describe("runInit", () => {
 
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
     expect(config.plugin).toBeDefined();
-    expect(config.plugin["micode-beads"]).toBeDefined();
+    expect(Array.isArray(config.plugin)).toBe(true);
+    expect(config.plugin).toContain("micode-beads");
   });
 
   it("should update existing opencode.json to include micode-beads plugin", async () => {
@@ -54,23 +55,22 @@ describe("runInit", () => {
 
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
     expect(config.model).toBe("openai/gpt-4o");
-    expect(config.plugin["some-other-plugin"]).toBeDefined();
-    expect(config.plugin["micode-beads"]).toBeDefined();
+    expect(config.plugin).toContain("some-other-plugin");
+    expect(config.plugin).toContain("micode-beads");
   });
 
   it("should not modify opencode.json when micode-beads is already configured (idempotent)", async () => {
     const configPath = join(tmpDir, "opencode.json");
     const original = {
-      plugin: {
-        "micode-beads": { custom: "setting" },
-      },
+      plugin: ["micode-beads"],
     };
     writeFileSync(configPath, JSON.stringify(original, null, 2));
 
     await runInit([]);
 
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
-    expect(config.plugin["micode-beads"]).toEqual({ custom: "setting" });
+    expect(config.plugin).toContain("micode-beads");
+    expect(config.plugin).toHaveLength(1);
   });
 
   it("should create thoughts/ directory structure", async () => {
@@ -115,7 +115,7 @@ describe("runInit", () => {
 
     const configPath = join(tmpDir, "opencode.json");
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
-    expect(config.plugin["micode-beads"]).toBeDefined();
+    expect(config.plugin).toContain("micode-beads");
 
     expect(existsSync(join(tmpDir, "thoughts", "ledgers"))).toBe(true);
   });


### PR DESCRIPTION
## Summary

- Fix `doctor --fix` and `init` writing `plugin` as object instead of array, which produced invalid opencode.json that prevented opencode from starting
- Change `opencode-json-valid` fix from destructive (replace entire file) to MANUAL, preserving user model/provider/plugin settings
- Migrate existing object-format plugins to array format when patching
- Silence optional dependency warnings (btca, ast-grep) behind `MICODE_VERBOSE` env var

Closes #19

## Test plan
- [x] 811/812 tests passing (1 pre-existing PTY failure)
- [x] Biome lint/format clean
- [x] Verified `opencode --version` works after config fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)