### PR TITLE
fix(ci): correct bun coverage flags and add codecov config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: bun run build
 
       - name: Test with coverage
-        run: bun test --coverage --coverageReporter=lcov --coverageDir=./coverage
+        run: bun test --coverage --coverage-reporter=lcov
 
       - name: Upload coverage reports to Codecov
         if: ${{ !github.event.pull_request.head.repo.fork && (github.event_name == 'push' || github.event_name == 'pull_request') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
         run: bun run build
 
       - name: Test with coverage
-        run: bun test --coverage --coverage-reporter=lcov
+        run: bun test --coverage
 
       - name: Upload coverage reports to Codecov
-        if: ${{ !github.event.pull_request.head.repo.fork && (github.event_name == 'push' || github.event_name == 'pull_request') }}
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,8 @@ yarn.lock
 # Worktrees
 .worktrees/
 
+# Coverage output
+coverage/
+
 # rp1 working files
 .rp1/

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+coverageReporter = ["text", "lcov"]
+coverageSkipTestFiles = true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+  ignore:
+    - "dist/**"
+    - "demo/**"
+    - "tests/**"
+
+comment:
+  layout: "condensed_header, condensed_files, condensed_footer"
+  require_changes: true

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "bun run typecheck",
     "test": "bun test",
-    "test:coverage": "bun test --coverage --coverageReporter=lcov --coverageDir=./coverage",
+    "test:coverage": "bun test --coverage --coverage-reporter=lcov",
     "test:e2e": "bun test tests/e2e/",
     "test:watch": "bun test --watch",
     "demo": "cd demo && bun run orchestrator.ts",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "bun run typecheck",
     "test": "bun test",
-    "test:coverage": "bun test --coverage --coverage-reporter=lcov",
+    "test:coverage": "bun test --coverage",
     "test:e2e": "bun test tests/e2e/",
     "test:watch": "bun test --watch",
     "demo": "cd demo && bun run orchestrator.ts",


### PR DESCRIPTION
## Summary
- Fix `--coverageReporter=lcov` → correct Bun CLI syntax (was Jest syntax, silently ignored)
- Add `bunfig.toml` with `coverageReporter = ["text", "lcov"]` so CI just needs `bun test --coverage`
- Add `codecov.yml` with project/patch thresholds, PR comment layout, and ignore patterns
- Add `coverage/` to `.gitignore`
- Simplify CI upload condition and `test:coverage` script

## Root cause
The original flags (`--coverageReporter=lcov --coverageDir=./coverage`) are Jest syntax. Bun silently ignored them, so `coverage/lcov.info` was never generated. Codecov reported "No coverage reports found."

## New files
- **`bunfig.toml`** — configures lcov reporter and skips test files from coverage stats
- **`codecov.yml`** — `target: auto` (no regression), `patch: 80%` (new code), PR comments enabled

## Verification
Tested locally — `bun test --coverage` (with bunfig.toml) produces `coverage/lcov.info` (66KB, 7024 lines).

## Test plan
- [ ] CI passes and Codecov upload step succeeds
- [ ] Codecov dashboard shows coverage data after merge
- [ ] Subsequent PRs get Codecov comments with coverage diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)